### PR TITLE
feat: Implement get product by ID functionality

### DIFF
--- a/lib/features/home_screen/tabs/home_tab/cubit/home_cubit.dart
+++ b/lib/features/home_screen/tabs/home_tab/cubit/home_cubit.dart
@@ -76,6 +76,17 @@ class HomeCubit extends Cubit<HomeState> {
       emit(ProductsError(e.toString()));
     }
   }
+  Future<void> getProductById(String id) async {
+    emit(GetProductByIdLoading());
+
+    try {
+      final product = await homeRepository.getProductById(id);
+      emit(GetProductByIdSuccess(product));
+    } catch (e) {
+      emit(GetProductByIdError(e.toString()));
+    }
+  }
+
 
   Map<String, List<Product>> _separateProductsByCategory(ProductResponse response) {
     final products = response.data ?? [];

--- a/lib/features/home_screen/tabs/home_tab/cubit/home_state.dart
+++ b/lib/features/home_screen/tabs/home_tab/cubit/home_state.dart
@@ -32,3 +32,16 @@ class ProductsError extends HomeState {
 
   ProductsError(this.message);
 }
+
+class GetProductByIdSuccess extends HomeState {
+  final Product product;
+  GetProductByIdSuccess(this.product);
+}
+
+class GetProductByIdLoading extends HomeState {
+}
+
+class GetProductByIdError extends HomeState {
+  final String message;
+  GetProductByIdError(this.message);
+}

--- a/lib/features/home_screen/tabs/home_tab/data/home_repo/home_repo.dart
+++ b/lib/features/home_screen/tabs/home_tab/data/home_repo/home_repo.dart
@@ -42,6 +42,22 @@ class HomeRepository {
     }
   }
 
+  Future<Product> getProductById(String id) async {
+    try {
+      final response = await DioHelper.get(
+        "${ApiConstant.productEndPoint}/$id",
+      );
+
+      return Product.fromJson(response.data['data']);
+    } on DioException catch (e) {
+      if (e.response != null) {
+        throw Exception(e.response?.data['message'] ?? 'Failed to load product');
+      } else {
+        throw Exception('Network Error: ${e.message}');
+      }
+    }
+  }
+
 
 
 

--- a/lib/features/home_screen/tabs/home_tab/data/model/get_product_by_id_response.dart
+++ b/lib/features/home_screen/tabs/home_tab/data/model/get_product_by_id_response.dart
@@ -1,0 +1,144 @@
+class GetProductByIdResponse {
+  final ProductData data;
+
+  GetProductByIdResponse({required this.data});
+
+  factory GetProductByIdResponse.fromJson(Map<String, dynamic> json) {
+    return GetProductByIdResponse(
+      data: ProductData.fromJson(json['data']),
+    );
+  }
+}
+
+class ProductData {
+  final int sold;
+  final List<String> images;
+  final List<SubCategory> subcategory;
+  final int ratingsQuantity;
+  final String id;
+  final String title;
+  final String slug;
+  final String description;
+  final int quantity;
+  final int price;
+  final String imageCover;
+  final Category category;
+  final Brand brand;
+  final double ratingsAverage;
+  final String createdAt;
+  final String updatedAt;
+  final List<dynamic> reviews;
+
+  ProductData({
+    required this.sold,
+    required this.images,
+    required this.subcategory,
+    required this.ratingsQuantity,
+    required this.id,
+    required this.title,
+    required this.slug,
+    required this.description,
+    required this.quantity,
+    required this.price,
+    required this.imageCover,
+    required this.category,
+    required this.brand,
+    required this.ratingsAverage,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.reviews,
+  });
+
+  factory ProductData.fromJson(Map<String, dynamic> json) {
+    return ProductData(
+      sold: json['sold'],
+      images: List<String>.from(json['images']),
+      subcategory: (json['subcategory'] as List)
+          .map((e) => SubCategory.fromJson(e))
+          .toList(),
+      ratingsQuantity: json['ratingsQuantity'],
+      id: json['id'],
+      title: json['title'],
+      slug: json['slug'],
+      description: json['description'],
+      quantity: json['quantity'],
+      price: json['price'],
+      imageCover: json['imageCover'],
+      category: Category.fromJson(json['category']),
+      brand: Brand.fromJson(json['brand']),
+      ratingsAverage: (json['ratingsAverage'] as num).toDouble(),
+      createdAt: json['createdAt'],
+      updatedAt: json['updatedAt'],
+      reviews: json['reviews'] ?? [],
+    );
+  }
+}
+
+class SubCategory {
+  final String id;
+  final String name;
+  final String slug;
+  final String category;
+
+  SubCategory({
+    required this.id,
+    required this.name,
+    required this.slug,
+    required this.category,
+  });
+
+  factory SubCategory.fromJson(Map<String, dynamic> json) {
+    return SubCategory(
+      id: json['_id'],
+      name: json['name'],
+      slug: json['slug'],
+      category: json['category'],
+    );
+  }
+}
+
+class Category {
+  final String id;
+  final String name;
+  final String slug;
+  final String image;
+
+  Category({
+    required this.id,
+    required this.name,
+    required this.slug,
+    required this.image,
+  });
+
+  factory Category.fromJson(Map<String, dynamic> json) {
+    return Category(
+      id: json['_id'],
+      name: json['name'],
+      slug: json['slug'],
+      image: json['image'],
+    );
+  }
+}
+
+class Brand {
+  final String id;
+  final String name;
+  final String slug;
+  final String image;
+
+  Brand({
+    required this.id,
+    required this.name,
+    required this.slug,
+    required this.image,
+  });
+
+  factory Brand.fromJson(Map<String, dynamic> json) {
+    return Brand(
+      id: json['_id'],
+      name: json['name'],
+      slug: json['slug'],
+      image: json['image'],
+    );
+  }
+}

--- a/lib/features/home_screen/tabs/home_tab/peresentaion/home_tab.dart
+++ b/lib/features/home_screen/tabs/home_tab/peresentaion/home_tab.dart
@@ -37,9 +37,12 @@ class _HomeTabState extends State<HomeTab> {
             children: [
               Row(
                 children: [
-                  CircleAvatar(
-                    radius: 22.w,
-                    backgroundImage: AssetImage(AppAssets.orderPhoto),
+                  InkWell(
+                    onTap: () => context.read<HomeCubit>().getProductById("6428ebc6dc1175abc65ca0b9"),
+                    child: CircleAvatar(
+                      radius: 22.w,
+                      backgroundImage: AssetImage(AppAssets.orderPhoto),
+                    ),
                   ),
                   SizedBox(width: 8.w),
                   Expanded(


### PR DESCRIPTION
This commit introduces the functionality to fetch a single product by its ID.

- **API & Repository**:
    - Added `getProductById` to `HomeRepo` to handle the API call to the `/api/v1/products/{id}` endpoint.

- **State Management (Cubit)**:
    - Implemented the `getProductById` method in `HomeCubit`.
    - Added new states (`GetProductByIdLoading`, `GetProductByIdSuccess`, `GetProductByIdError`) to manage the async operation's lifecycle.

- **Data Model**:
    - Created a new `GetProductByIdResponse` model to parse the JSON response for a single product.

- **UI (Temporary)**:
    - Added a temporary `onTap` event in `home_tab.dart` to test the new functionality.